### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ TheCodeShip
 
 Minimalist personal blog built with Django.
 
-###Features
+### Features
 + Django 1.4 based blog
 + Posts, categories and sub categories
 + Post has status published/unpublished
@@ -15,7 +15,7 @@ Minimalist personal blog built with Django.
 + RSS Feeds
 + Apps installed: TinyMCE, taggit(for post tags)
 
-#####Todo:
+##### Todo:
 + Print friendly CSS + print hyperlink for posts
 + Allow admin to re-organize the category menu order(make it order elements by default by length small to large)
 + View to receive requests from authenticated client to post new articles via JSON-RPC


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
